### PR TITLE
Updated version notebook after technical review

### DIFF
--- a/notebooks/NIRCAM/JWpipeNB-nircam-imaging.ipynb
+++ b/notebooks/NIRCAM/JWpipeNB-nircam-imaging.ipynb
@@ -1454,7 +1454,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6615b298-ae83-491a-bfa6-888bcd21ea9e",
+   "id": "06402509-0353-415e-bf1b-5f88af4547f2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1484,6 +1484,90 @@
     "    viewer_lw_i2d.stretch = 'sqrt'\n",
     "    viewer_lw_i2d.set_colormap('Viridis')\n",
     "    viewer_lw_i2d.cuts = '95%'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d94fa17-9f9f-4a6b-a429-509b41b85eb1",
+   "metadata": {},
+   "source": [
+    "Let's try putting the SW and LW images on top of one another to create a color image. This should work regardless of whether you resampled the two images onto the same pixel grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e27c954-fc64-4c44-841e-f420903de226",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage3:\n",
+    "    imviz_color = Imviz()\n",
+    "    viewer_color = imviz_color.default_viewer\n",
+    "\n",
+    "    # Load the datasets into Imviz\n",
+    "    imviz_color.load_data(sw_i2d_file, data_label='sw')\n",
+    "    imviz_color.load_data(lw_i2d_file, data_label='lw')\n",
+    "\n",
+    "    # Link images by WCS (without affine approximation)\n",
+    "    imviz_color.plugins['Links Control'].link_type = 'WCS'\n",
+    "    imviz_color.plugins['Links Control'].wcs_use_affine = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "977092a3-3838-47ba-9040-f5eb819e3d1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define some options to make the picture look nice. Set the colors\n",
+    "# for the two images. \n",
+    "if doimage3:\n",
+    "    plot_options = imviz_color.plugins['Plot Options']\n",
+    "    plot_options.image_color_mode = 'Monochromatic'\n",
+    "    img_settings = {'sw': {'image_color': '#61d3e1',\n",
+    "                           #'stretch_vmin': 0,\n",
+    "                           #'stretch_vmax': 4,\n",
+    "                           #'image_opacity': 0.32,\n",
+    "                           #'image_contrast': 0.69,\n",
+    "                           #'image_bias': 0.39\n",
+    "                          },\n",
+    "                    'lw': {'image_color': '#ff767c',\n",
+    "                           #'stretch_vmin': 0,\n",
+    "                           #'stretch_vmax': 16,\n",
+    "                           #'image_opacity': 0.4,\n",
+    "                           #'image_contrast': 0.94,\n",
+    "                           #'image_bias': 0.74\n",
+    "                          }\n",
+    "                   }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aaca2457-d10d-4d94-89a7-e46e6528acf5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now populate the imviz instance with the settings in the cell above.\n",
+    "if doimage3:\n",
+    "    for layer, settings in img_settings.items():\n",
+    "        plot_options.layer = f'{layer}[DATA]'\n",
+    "        for k, v in settings.items():\n",
+    "            setattr(plot_options, k, v)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed6cd5f7-77ba-49ae-b4b2-20e00e26144d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the dataset\n",
+    "if doimage3:\n",
+    "    imviz_color.show()"
    ]
   },
   {
@@ -1667,7 +1751,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
New

NIRCam Imaging Notebook - Code Review

Updated information sections format
Updated paragraph for CRDS as we are now moving into Data rRelease mode
Fixed links to sections.
Added number to Notes section to be 9. This for consinstency
Added a link to MAST search page
In Cell 2 changes the user_home_dir to the PID and Obs given in this notebook
Changed the context to use the context that applies to build 1.15.1 
Changed wording in the CRDS cell to read 
#“Set CRDS context (if overriding to use a specific version of reference
# files; leave commented out to use the default context. This is, the latest 
# reference files associated with the version of the calibration pipeline)”

# Implementation to associate a context with a version of the jwst Calibration
# pipeline will be released soon, until that happens we will set the context to the 
# correct one for the version of the jwst Calibration pipeline used here.

This assumes that by the time this notebooks is public CRDS would be able to assign a context with the given version of the calibration pipeline; however, things are taking longer

Added a few comments to the cell to clarify what was happening. Nothing major.
Changed the AsdfFile path to Image3 directory, otherwise the code crashes.
14. Added information about the filter correspondence to SW and LW cases in description
15. When creating the association I clarified F200W = SW and F444W = LW
16. Changed mention to image3_fxxxw products in the Visualization section as the data was not named that way throughout the notebook.
17. Added the cells for Imvix to overly the observations that Bryan added 
