### PR TITLE
Tech revie NRC Imaging notebook

### DIFF
--- a/notebooks/NIRCAM/JWpipeNB-nircam-imaging.ipynb
+++ b/notebooks/NIRCAM/JWpipeNB-nircam-imaging.ipynb
@@ -25,8 +25,7 @@
    "id": "7da2029f",
    "metadata": {},
    "source": [
-    "**Purpose**:\n",
-    "\n",
+    "**Purpose**:<BR>\n",
     "This notebook provides a framework for processing generic Near-Infrared\n",
     "Camera (NIRCam) Imaging data through all three James Webb Space Telescope\n",
     "(JWST) pipeline stages.  Data is assumed to be located in a folder structure\n",
@@ -34,26 +33,26 @@
     "any cells other than in the [Configuration](#1.-Configuration) section unless\n",
     "modifying the standard pipeline processing options.\n",
     "\n",
-    "**Data**:\n",
+    "**Data**:<BR>\n",
     "This example is set up to use an example dataset is from\n",
     "[Program ID](https://www.stsci.edu/jwst/science-execution/program-information)\n",
     "2739 (PI: Pontoppidan) which is a Cycle 1 Outreach program. \n",
-    "We focus on the data from Observation 002, in which M-16, or the\n",
+    "We focus on the data from Observation 001 Visit 002, in which M-16, or the\n",
     "\"Pillars of Creation\" were observed.\n",
-    "\n",
     "Example input data to use will be downloaded automatically unless\n",
     "disabled (i.e., to use local files instead).\n",
     "\n",
-    "**JWST pipeline version and CRDS context** This notebook was written for the\n",
-    "calibration pipeline version given above. It sets the CRDS context\n",
-    "to use the most recent version available in the JWST Calibration\n",
-    "Reference Data System (CRDS). If you use different pipeline versions or\n",
+    "**JWST pipeline version and CRDS context**:<BR>\n",
+    "This notebook was written for the calibration pipeline version given \n",
+    "above. It sets the CRDS context to the latest context in the JWST \n",
+    "Calibration Reference Data System (CRDS) associated with that\n",
+    "pipeline version. If you use different pipeline versions or\n",
     "CRDS context, please read the relevant release notes\n",
     "([here for pipeline](https://github.com/spacetelescope/jwst),\n",
     "[here for CRDS](https://jwst-crds.stsci.edu/)) for possibly relevant\n",
     "changes.<BR>\n",
     "\n",
-    "**Updates**:\n",
+    "**Updates**:<BR>\n",
     "This notebook is regularly updated as improvements are made to the\n",
     "pipeline. Find the most up to date version of this notebook at:\n",
     "https://github.com/spacetelescope/jwst-pipeline-notebooks/\n",
@@ -70,14 +69,14 @@
     "\n",
     "## Table of Contents\n",
     "1. [Configuration](#Configuration) \n",
-    "2. [Package Imports](#Package-Imports)\n",
-    "3. [Demo Mode Setup (ignore if not using demo data)](#Demo-Mode-Setup-(ignore-if-not-using-demo-data))\n",
-    "4. [Directory Setup](#Directory-Setup)\n",
-    "5. [Detector1 Pipelineg](#Detector1-Pipeline)\n",
-    "6. [Image2 Pipeline](#Image2-Pipeline)\n",
-    "7. [Image3 Pipeline](#Image3-Pipeline)\n",
-    "8. [Visualize the resampled images](#Visualize-the-resampled-images)\n",
-    "9. [Notes](#Notes)"
+    "2. [Package Imports](#2.-Package-Imports)\n",
+    "3. [Demo Mode Setup (ignore if not using demo data)](#3.-Demo-Mode-Setup-(ignore-if-not-using-demo-data))\n",
+    "5. [Directory Setup](#4.-Directory-Setup)\n",
+    "6. [Detector1 Pipelineg](#5.-Detector1-Pipeline)\n",
+    "7. [Image2 Pipeline](#6.-Image2-Pipeline)\n",
+    "8. [Image3 Pipeline](#7.-Image3-Pipeline)\n",
+    "9. [Visualize the resampled images](#8.-Visualize-the-resampled-images)\n",
+    "10. [Notes](#9.-Notes)"
    ]
   },
   {
@@ -152,10 +151,10 @@
     "\n",
     "Set <code>demo_mode = True </code> to run in demonstration mode. In this\n",
     "mode this notebook will download example data from the Barbara A.\n",
-    "Mikulski Archive for Space Telescopes (MAST) and process it through the\n",
-    "pipeline. This will all happen in a local directory unless modified\n",
-    "in [Section 3](#3.-Demo-Mode-Setup-(ignore-if-not-using-demo-data))\n",
-    "below. \n",
+    "Mikulski Archive for Space Telescopes \n",
+    "([MAST](https://mast.stsci.edu/search/ui/#/jwst)) and process it through \n",
+    "the pipeline. This will all happen in a local directory unless modified in \n",
+    "[Section 3](#3.-Demo-Mode-Setup-(ignore-if-not-using-demo-data)) below. \n",
     "\n",
     "Set <code>demo_mode = False</code> if you want to process your own data\n",
     "that has already been downloaded and provide the location of the data.<br>"
@@ -188,7 +187,7 @@
     "    # Point to where science observation data are\n",
     "    # Assumes uncalibrated data in <sci_dir>/uncal/ and results in stage1,\n",
     "    # stage2, stage3 directories\n",
-    "    sci_dir = os.path.join(user_home_dir, 'PID3729/Obs001/')\n",
+    "    sci_dir = os.path.join(user_home_dir, 'PID2739/Obs002/')\n",
     "\n",
     "# --------------------------Set Processing Steps--------------------------\n",
     "# Individual pipeline stages can be turned on/off here.  Note that a later\n",
@@ -226,8 +225,13 @@
     "# ------------------------Set CRDS context and paths----------------------\n",
     "\n",
     "# Set CRDS context (if overriding to use a specific version of reference\n",
-    "# files; leave commented out to use latest reference files by default)\n",
-    "#%env CRDS_CONTEXT  jwst_1254.pmap\n",
+    "# files; leave commented out to use the default context. This is, the latest \n",
+    "# reference files associated with the version of the calibration pipeline)\n",
+    "\n",
+    "# Implementation to associate a context with a version of the jwst Calibration\n",
+    "# pipeline will be released soon, until that happens we will set the context to the \n",
+    "# correct one for the version of the jwst Calibration pipeline used here.\n",
+    "%env CRDS_CONTEXT jwst_1293.pmap\n",
     "\n",
     "# Check whether the local CRDS cache directory has been set.\n",
     "# If not, set it to the user home directory\n",
@@ -239,7 +243,8 @@
     "\n",
     "# Echo CRDS path in use\n",
     "print(f\"CRDS local filepath: {os.environ['CRDS_PATH']}\")\n",
-    "print(f\"CRDS file server: {os.environ['CRDS_SERVER_URL']}\")"
+    "print(f\"CRDS file server: {os.environ['CRDS_SERVER_URL']}\")\n",
+    "print(f\"CRDS CONTEXT: {os.environ['CRDS_CONTEXT']}\")"
    ]
   },
   {
@@ -279,16 +284,19 @@
     "# Numpy for doing calculations\n",
     "import numpy as np\n",
     "\n",
+    "# To display full ouptut of cell, not just the last result\n",
+    "from IPython.core.interactiveshell import InteractiveShell\n",
+    "InteractiveShell.ast_node_interactivity = \"all\"\n",
+    "\n",
     "# -----------------------Astroquery Imports--------------------------------\n",
     "# ASCII files, and downloading demo files\n",
     "from astroquery.mast import Observations\n",
     "\n",
-    "# For visualizing images\n",
-    "from jdaviz import Imviz\n",
-    "\n",
     "# Astropy routines for visualizing detected sources:\n",
     "from astropy.table import Table\n",
     "from astropy.coordinates import SkyCoord\n",
+    "\n",
+    "# ------------ Pipeline and  Visualization Imports -----------------------\n",
     "\n",
     "# for JWST calibration pipeline\n",
     "import jwst\n",
@@ -303,6 +311,9 @@
     "from jwst import datamodels\n",
     "from jwst.associations import asn_from_list  # Tools for creating association files\n",
     "from jwst.associations.lib.rules_level3_base import DMS_Level3_Base  # Definition of a Lvl3 association file\n",
+    "\n",
+    "# For visualizing images\n",
+    "from jdaviz import Imviz\n",
     "\n",
     "# Echo pipeline version and CRDS context in use\n",
     "print(f\"JWST Calibration Pipeline Version: {jwst.__version__}\")\n",
@@ -345,7 +356,8 @@
     "[F200W and F444W filters](https://jwst-docs.stsci.edu/jwst-near-infrared-camera/nircam-instrumentation/nircam-filters)\n",
     "and start with uncalibrated data products. The files are named\n",
     "`jw02739001002_02105_0000<dither>_nrc<det>_uncal.fits`, where *dither* refers to the\n",
-    " dither step number, and *det* is the detector name. \n",
+    "dither step number, and *det* is the detector name. Through this notebook we will refer to data\n",
+    "with filter `f200W` as SW data and `f444W` as LW data.\n",
     " \n",
     "More information about the JWST file naming conventions can be found at:\n",
     "https://jwst-pipeline.readthedocs.io/en/latest/jwst/data_products/file_naming.html"
@@ -386,7 +398,9 @@
     "Identify list of science (SCI) uncalibrated files associated with visits.\n",
     "<div class=\"alert alert-block alert-warning\">\n",
     "Work one filter at a time, so that we can more easily filter by detector and keep only the module A files.\n",
-    "</div>"
+    "</div>\n",
+    "\n",
+    "Download first the F200W data."
    ]
   },
   {
@@ -443,7 +457,7 @@
     "            sci_files_to_download.extend(filtered_products['dataURI'])\n",
     "\n",
     "    # To limit data volume, keep only files from visit 002, dithers 1 and 2, and only A-module\n",
-    "    sw_sci_files_to_download = [fname for fname in sci_files_to_download if 'jw02739001002_02105' in fname and \\\n",
+    "    sw_sci_files_to_download = [fname for fname in sci_files_to_download if 'jw02739001002_02105' in fname and \n",
     "                                ('nrca2' in fname or 'nrca4' in fname) and ('00001' in fname or '00002' in fname)]\n",
     "    sw_sci_files_to_download = sorted(sw_sci_files_to_download)\n",
     "    print(f\"Science files selected for downloading: {len(sw_sci_files_to_download)}\")"
@@ -456,6 +470,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# List the SW files to download\n",
     "sw_sci_files_to_download"
    ]
   },
@@ -521,7 +536,7 @@
     "            sci_files_to_download.extend(filtered_products['dataURI'])\n",
     "\n",
     "    # To limit data volume, keep only files from visit 002, dithers 1 and 2, and only A-module\n",
-    "    lw_sci_files_to_download = [fname for fname in sci_files_to_download if 'jw02739001002_02105' in fname and \\\n",
+    "    lw_sci_files_to_download = [fname for fname in sci_files_to_download if 'jw02739001002_02105' in fname and \n",
     "                                'nrca' in fname and ('00001' in fname or '00002' in fname)]\n",
     "    lw_sci_files_to_download = sorted(lw_sci_files_to_download)\n",
     "    print(f\"Science files selected for downloading: {len(lw_sci_files_to_download)}\")"
@@ -534,7 +549,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lw_sci_files_to_download"
+    "# List of files to download per wavelength\n",
+    "\n",
+    "print(f'\\nSW data to download {sw_sci_files_to_download}')\n",
+    "print(f'LW data to download {lw_sci_files_to_download}')"
    ]
   },
   {
@@ -544,6 +562,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Full list the science files to download\n",
     "sci_files_to_download = sw_sci_files_to_download + lw_sci_files_to_download\n",
     "sci_files_to_download"
    ]
@@ -633,13 +652,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# List uncal files\n",
     "uncal_files = sorted(glob.glob(os.path.join(uncal_dir, '*_uncal.fits')))\n",
     "\n",
-    "# print file name\n",
+    "# Separate SW fro LW files\n",
     "sw_uncal_files = [uncfile for uncfile in uncal_files if 'long' not in uncfile]\n",
     "lw_uncal_files = [uncfile for uncfile in uncal_files if 'long' in uncfile]\n",
     "\n",
-    "# Open file as JWST datamodel\n",
+    "# Open one SW adn one LW file as JWST datamodel\n",
     "sw_examine = datamodels.open(sw_uncal_files[0])\n",
     "lw_examine = datamodels.open(lw_uncal_files[0])\n",
     "\n",
@@ -703,10 +723,10 @@
     "created (nintegrations x nrows x ncols) which have the fitted ramp slopes\n",
     "for each integration.\n",
     "\n",
-    "By default, all steps in the Detector1 stage of the pipeline are run for\n",
+    "By default, all steps in the `Detector1` stage of the pipeline are run for\n",
     "NIRCam except: the `ipc` correction step and the `gain_scale` step. Note\n",
     "that the [`persistence` step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/persistence/description.html)\n",
-    "has been turned off by default starting with CRDS context jwst_1264.pmap.\n",
+    "has been turned off by default starting with CRDS context `jwst_1264.pmap`.\n",
     "This step does not automatically correct the science data for persistence.\n",
     "The `persistence` step creates a `*_trapsfilled.fits` file which is a model\n",
     "that records the number of traps filled at each pixel at the end of an exposure.\n",
@@ -722,7 +742,7 @@
     "\n",
     "As of CRDS context `jwst_1155.pmap` and later, the \n",
     "[`jump` step](https://jwst-pipeline.readthedocs.io/en/latest/api/jwst.jump.JumpStep.html)\n",
-    "of the `DETECTOR1` stage of the pipeline will remove signal associated\n",
+    "of the `Detector1` stage of the pipeline will remove signal associated\n",
     "with [snowballs](https://jwst-docs.stsci.edu/known-issues-with-jwst-data/shower-and-snowball-artifacts)\n",
     "in the NIRCam imaging mode. This correction is turned on using the parameter\n",
     "`expand_large_events=True`. This and other parameters related to the snowball correction\n",
@@ -755,22 +775,22 @@
     "# Overrides for various reference files\n",
     "# Files should be in the base local directory or provide full path\n",
     "#det1dict['dq_init']['override_mask'] = 'myfile.fits' # Bad pixel mask\n",
-    "#det1dict['saturation']['override_saturation'] = 'myfile.fits' # Saturation\n",
-    "#det1dict['reset']['override_reset'] = 'myfile.fits' # Reset\n",
-    "#det1dict['linearity']['override_linearity'] = 'myfile.fits' # Linearity\n",
-    "#det1dict['rscd']['override_rscd'] = 'myfile.fits' # RSCD\n",
-    "#det1dict['dark_current']['override_dark'] = 'myfile.fits' # Dark current subtraction\n",
-    "#det1dict['jump']['override_gain'] = 'myfile.fits' # Gain used by jump step\n",
-    "#det1dict['ramp_fit']['override_gain'] = 'myfile.fits' # Gain used by ramp fitting step\n",
-    "#det1dict['jump']['override_readnoise'] = 'myfile.fits' # Read noise used by jump step\n",
-    "#det1dict['ramp_fit']['override_readnoise'] = 'myfile.fits' # Read noise used by ramp fitting step\n",
+    "#det1dict['saturation']['override_saturation'] = 'myfile.fits'  # Saturation\n",
+    "#det1dict['reset']['override_reset'] = 'myfile.fits'  # Reset\n",
+    "#det1dict['linearity']['override_linearity'] = 'myfile.fits'  # Linearity\n",
+    "#det1dict['rscd']['override_rscd'] = 'myfile.fits'  # RSCD\n",
+    "#det1dict['dark_current']['override_dark'] = 'myfile.fits'  # Dark current subtraction\n",
+    "#det1dict['jump']['override_gain'] = 'myfile.fits'  # Gain used by jump step\n",
+    "#det1dict['ramp_fit']['override_gain'] = 'myfile.fits'  # Gain used by ramp fitting step\n",
+    "#det1dict['jump']['override_readnoise'] = 'myfile.fits'  # Read noise used by jump step\n",
+    "#det1dict['ramp_fit']['override_readnoise'] = 'myfile.fits'  # Read noise used by ramp fitting step\n",
     "\n",
     "# Turn on multi-core processing (This is off by default). Choose what fraction\n",
     "# of cores to use (quarter, half, all, or an integer number)\n",
     "det1dict['jump']['maximum_cores'] = 'half'\n",
     "\n",
     "# Explicitly turn on snowball correction. (Even though it is on by default)\n",
-    "det1dict['jump']['expand_large_events'] = True\n"
+    "det1dict['jump']['expand_large_events'] = True"
    ]
   },
   {
@@ -778,7 +798,7 @@
    "id": "c1495ec7-633d-425d-a9e7-cbf9f8a6580d",
    "metadata": {},
    "source": [
-    "Run the Detector1 pipeline on all input date, regardless of filter."
+    "Run the `Detector1` pipeline on all input data, regardless of filter."
    ]
   },
   {
@@ -968,6 +988,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# List rate files\n",
     "rate_files"
    ]
   },
@@ -996,7 +1017,7 @@
     "    for rate in rate_files:\n",
     "        cal_result = Image2Pipeline.call(rate, output_dir=image2_dir, steps=image2dict, save_results=True)\n",
     "else:\n",
-    "    print(\"Skipping Image2 processing.\")\n"
+    "    print(\"Skipping Image2 processing.\")"
    ]
   },
   {
@@ -1027,9 +1048,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Identify *_cal.fits files\n",
+    "# Identify *_cal.fits file products\n",
     "cal_files = sorted(glob.glob(os.path.join(image2_dir, '*_cal.fits')))\n",
     "\n",
+    "# Select first file to gather information\n",
     "cal_f = datamodels.open(cal_files[0])\n",
     "\n",
     "# Check which steps were run:\n",
@@ -1070,9 +1092,9 @@
     "- [tweakreg](https://jwst-pipeline.readthedocs.io/en/latest/jwst/tweakreg/index.html#tweakreg-step) - creates source catalogs of pointlike sources for each input image. The source catalog for each input image is compared to each other to derive coordinate transforms to align the images relative to each other.\n",
     "   - `tweakreg` has many [input parameters](https://jwst-pipeline.readthedocs.io/en/latest/jwst/tweakreg/README.html#step-arguments) that can be adjusted to improve the image alignment in cases where the default values do not perform well.\n",
     "   - One tweakreg parameter that is not set by default but can be very useful is `abs_refcat`. When this parameter is set to `GAIADR3`, the tweakreg step performs an absolute astrometric correction of the data using the GAIA data release 3 catalog. In cases where multiple unsaturated GAIA stars are present in the input images, this can improve the absolute astrometric alignment. However, in sparse or very crowded fields, this can potentially result in poor performance, so users are encouraged to check astrometric accuracy and revisit this step if necessary.\n",
-    "   - As of pipeline version 1.14.0, the default source finding algorithm in the `tweakreg step` is `IRAFStarFinder`. Other options include `DAOStarFinder`, whose results are not as good in cases where the PSF is undersampled, such as in the blue filters of the NIRCam shortwave channel, and [photutils segmentation SourceFinder](https://photutils.readthedocs.io/en/latest/api/photutils.segmentation.SourceFinder.html), which does not assume sources are point-like.\n",
+    "   - As of pipeline version 1.14.0, the default source finding algorithm in the `tweakreg step` is `IRAFStarFinder`. Other options include `DAOStarFinder`, whose results are not as good in cases where the PSF is undersampled, such as in the blue filters of the NIRCam shortwave channel. Finally [photutils segmentation SourceFinder](https://photutils.readthedocs.io/en/latest/api/photutils.segmentation.SourceFinder.html), which does not assume sources are point-like.\n",
     "- [skymatch](https://jwst-pipeline.readthedocs.io/en/latest/jwst/skymatch/index.html#skymatch-step) - measures the background level from the sky to use as input into the subsequent `outlier detection` and `resample` steps.\n",
-    "- [outlier detection](https://jwst-pipeline.readthedocs.io/en/latest/jwst/outlier_detection/index.html#outlier-detection-step) - flags any remaining cosmic rays, bad pixels, or other artifacts not already flagged during the `DETECTOR1` stage of the pipeline, using all input images to create a median image so that outliers in individual images can be identified.\n",
+    "- [outlier detection](https://jwst-pipeline.readthedocs.io/en/latest/jwst/outlier_detection/index.html#outlier-detection-step) - flags any remaining cosmic rays, bad pixels, or other artifacts not already flagged during the `Detector1` stage of the pipeline, using all input images to create a median image so that outliers in individual images can be identified.\n",
     "- [resample](https://jwst-pipeline.readthedocs.io/en/latest/jwst/resample/index.html#resample-step) - resamples each input image based on its WCS and distortion information and creates a single undistorted image.\n",
     "- [source catalog](https://jwst-pipeline.readthedocs.io/en/latest/jwst/source_catalog/index.html#source-catalog-step) - creates a catalog of detected sources along with photometric results and morphologies (i.e., point-like vs extended). These catalogs are generally useful for quick checks, but optimization is likely needed for specific science cases. Users may wish to experiment with changing the `snr_threshold` and `deblend` options. Modifications to the following parameters will not significantly improve data quality and it is advised to keep them at their default values: `aperture_ee1`, `aperture_ee2`, `aperture_ee3`, `ci1_star_threshold`, `ci2_star_threshold`."
    ]
@@ -1107,7 +1129,7 @@
     "# Overrides for various reference files\n",
     "# Files should be in the base local directory or provide full path\n",
     "#image3dict['source_catalog']['override_apcorr'] = 'myfile.fits'  # Aperture correction parameters\n",
-    "#image3dict['source_catalog']['override_abvegaoffset'] = 'myfile.asdf' # Data to convert from AB to Vega magnitudes (ASDF file)\n",
+    "#image3dict['source_catalog']['override_abvegaoffset'] = 'myfile.asdf'  # Data to convert from AB to Vega magnitudes (ASDF file)\n",
     "\n",
     "# Turn on alignment to GAIA in the tweakreg step\n",
     "# For data such as these demo data, where there are some heavily saturated stars in the field\n",
@@ -1136,6 +1158,7 @@
     "sw_sstring = os.path.join(image2_dir, 'jw*nrc??_cal.fits')     # shortwave files. Detectors a1-a4, b1-b4\n",
     "lw_sstring = os.path.join(image2_dir, 'jw*nrc*long_cal.fits')  # longwave files. Detectors along, blong \n",
     "\n",
+    "# Identify SW and LW cal files\n",
     "sw_cal_files = sorted(glob.glob(sw_sstring))\n",
     "lw_cal_files = sorted(glob.glob(lw_sstring))\n",
     "\n",
@@ -1148,35 +1171,29 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e6550a4a-f924-410b-a945-effcef431e88",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sw_cal_files"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4712cd88-1a88-4557-a86e-8fa78bd91217",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lw_cal_files"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "db5cb6f5-44a1-4f28-95dc-b23a97451465",
    "metadata": {},
    "source": [
     "### Create Association File\n",
     "\n",
-    "An association file lists the files to calibrate together in `Stage 3` of the pipeline. Note that association files are available for download from MAST, with filenames of `*_asn.json`. Here we show how to create an association file to point to the data products created in the steps above. This is useful in cases where you want to work with a set of data that is different than that in the association files from MAST.\n",
+    "An association file lists the files to calibrate together in `Stage3` of the pipeline. Note that association files are available for download from MAST, with filenames of `*_asn.json`. Here we show how to create an association file to point to the data products created in the steps above. This is useful in cases where you want to work with a set of data that is different than that in the association files from MAST.\n",
     "\n",
-    "Note that the output products will have a rootname that is specified by the `product_name` in the association file. For this tutorial, the rootnames of the output products will be `image3_f200w` and `image3_f444w`.   XXXXXXXmake product names generic rather than filter specific???XXXXX"
+    "Note that the output products will have a rootname that is specified by the `product_name` in the association file. For this tutorial, the rootnames of the output products will be `image3_sw` for filter `F200W` and `image3_lw` for filter `F444W`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6550a4a-f924-410b-a945-effcef431e88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List of data to use\n",
+    "print('List of SW cal files to use:')\n",
+    "sw_cal_files\n",
+    "print('\\nList of LW cal files to use:')\n",
+    "lw_cal_files"
    ]
   },
   {
@@ -1188,7 +1205,7 @@
    },
    "outputs": [],
    "source": [
-    "# Create Level 3 Associations\n",
+    "# Create Level 3 Association for filter F200W products\n",
     "if doimage3:\n",
     "    sw_product_name = 'image3_sw'\n",
     "    sw_association = asn_from_list.asn_from_list(sw_cal_files,\n",
@@ -1214,6 +1231,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Create Level 3 Associations for filter F444W products\n",
     "if doimage3:\n",
     "    lw_product_name = 'image3_lw'\n",
     "    lw_association = asn_from_list.asn_from_list(lw_cal_files,\n",
@@ -1264,7 +1282,7 @@
    },
    "outputs": [],
    "source": [
-    "# Run Stage 3 on the LW data\n",
+    "# Run Stage3 on the LW data\n",
     "if doimage3:\n",
     "    lw_i2d_result = Image3Pipeline.call(lw_association_im3, output_dir=image3_dir, steps=image3dict, save_results=True)\n",
     "else:\n",
@@ -1287,13 +1305,14 @@
    "outputs": [],
    "source": [
     "if doimage3:\n",
+    "    # First we identify the dataset and read it using datamodels.\n",
     "    lw_i2d_file = os.path.join(image3_dir, f'{lw_product_name}_i2d.fits')\n",
     "    lw_data = datamodels.open(lw_i2d_file)\n",
     "    \n",
     "    # Pull out the resulting gWCS and save it in an asdf file\n",
     "    tree = {\"wcs\": lw_data.meta.wcs}\n",
     "    wcs_file = AsdfFile(tree)\n",
-    "    gwcs_filename = 'lw_gwcs.asdf'\n",
+    "    gwcs_filename = os.path.join(image3_dir + 'lw_gwcs.asdf')\n",
     "    print(f'Saving gWCS into {gwcs_filename}')\n",
     "    wcs_file.write_to(gwcs_filename)\n",
     "\n",
@@ -1314,7 +1333,7 @@
    "id": "00d4b708-66e8-485c-add2-95f7dd29af50",
    "metadata": {},
    "source": [
-    "Prepare to call the Image 3 pipeline on the SW data. If you wish to resample the SW data onto the same pixel grid as the LW data above, uncomment the lines below. This will tell the resample step to use the gWCS and the array size from the LW data when resampling the SW data."
+    "Prepare to call the Image3 pipeline on the SW data. If you wish to resample the SW data onto the same pixel grid as the LW data above, uncomment the lines below. This will tell the resample step to use the gWCS and the array size from the LW data when resampling the SW data."
    ]
   },
   {
@@ -1419,7 +1438,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c6f1ed63-0bed-412b-ab04-54caa7d61bbd",
+   "id": "bc5426a1-3932-4add-8e65-40939a9ee140",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1439,6 +1458,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e4654602-c6e9-4178-9b3d-9a219a1471df",
+   "metadata": {},
+   "source": [
+    "Remember that in this data science we have only two detectors nrc2 and nrc4 (left and right) respectively. THe ditter is not large enough to cover the gap. "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "8d22a117-e4cf-4d2f-9fec-f52545c8aa5a",
@@ -1454,7 +1481,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06402509-0353-415e-bf1b-5f88af4547f2",
+   "id": "6615b298-ae83-491a-bfa6-888bcd21ea9e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1488,16 +1515,20 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d94fa17-9f9f-4a6b-a429-509b41b85eb1",
+   "id": "e4797288-5db3-4c4e-bcd3-a1215527fab5",
    "metadata": {},
    "source": [
-    "Let's try putting the SW and LW images on top of one another to create a color image. This should work regardless of whether you resampled the two images onto the same pixel grid."
+    "### Ovelaying the LW and SW images\n",
+    "\n",
+    "Let's try putting the SW and LW images on top of one another to create a color image. This should work regardless of whether you resampled the two images onto the same pixel grid.\n",
+    "\n",
+    "Let's get the data first"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e27c954-fc64-4c44-841e-f420903de226",
+   "id": "f80f5fc7-a555-4201-88d5-e08318bd7e57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1515,14 +1546,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2b8d63a9-ecab-4164-b6bb-1fb82a7b73c6",
+   "metadata": {},
+   "source": [
+    "Now define some options to make the picture look nice."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "977092a3-3838-47ba-9040-f5eb819e3d1f",
+   "id": "709f92eb-beda-438a-90ec-340a7ac303a6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Define some options to make the picture look nice. Set the colors\n",
-    "# for the two images. \n",
+    "# Set the colors for the two images. \n",
     "if doimage3:\n",
     "    plot_options = imviz_color.plugins['Plot Options']\n",
     "    plot_options.image_color_mode = 'Monochromatic'\n",
@@ -1544,9 +1582,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "fd7c00b6-8a84-4d4d-a0dd-b73a1f355f17",
+   "metadata": {},
+   "source": [
+    "We populate the imviz instance with the settings in the cell above and visualize the dataset"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aaca2457-d10d-4d94-89a7-e46e6528acf5",
+   "id": "7c108af5-e54d-456f-bc30-d94901376c35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1561,7 +1607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed6cd5f7-77ba-49ae-b4b2-20e00e26144d",
+   "id": "b1186623-2ae7-4f21-87e2-be852af291fa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1576,7 +1622,7 @@
    "metadata": {},
    "source": [
     "## <a id='detections'>Visualize Detected Sources</a>\n",
-    "Using the source catalogs created by the `IMAGE3` stage of the pipeline, mark the detected sources, using different markers for point sources and extended sources. The source catalogs are saved in `image3/image3_f200w_cat.ecsv` and `image3/image3_f444w_cat.ecsv`. This time, we will provide the i2d filename to the `imviz` `load_data` function, rather than just the array of pixel values. This way, `imviz` will be able to make use of the World Coordinate System (WCS) in the file. This will allow the sources in the source catalog to be accurately marked in the display."
+    "Using the source catalogs created by the `Image3` stage of the pipeline, mark the detected sources, using different markers for point sources and extended sources. The source catalogs are saved in `image3/image3_sw_cat.ecsv` and `image3/image3_lw_cat.ecsv`. This time, we will provide the i2d filename to the `imviz` `load_data` function, rather than just the array of pixel values. This way, `imviz` will be able to make use of the World Coordinate System (WCS) in the file. This will allow the sources in the source catalog to be accurately marked in the display."
    ]
   },
   {
@@ -1625,13 +1671,15 @@
    "source": [
     "### Mark the extended and point sources on the images\n",
     "\n",
-    "Display the image with sources indicated by circles. Point sources will be marked by small pink circles and extended sources will be marked by white circles. Looking at the entire mosaic, there are so many sources found that it's hard to see much of anything. To get a clearer view, try zooming in on various areas using the magnifying glass icon on the banner immediately above the image. "
+    "Display the image with sources indicated by circles. Point sources will be marked by small pink circles and extended sources will be marked by white circles. Looking at the entire mosaic, there are so many sources found that it's hard to see much of anything. To get a clearer view, try zooming in on various areas using the magnifying glass icon on the banner immediately above the image. \n",
+    "\n",
+    "First we visualize the data without the point sources."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64860785-66a2-4624-acdc-031f6b0ab18c",
+   "id": "3126f030-973e-4bf9-972c-fcac9818c451",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1647,6 +1695,14 @@
     "    viewer_sw_cat.cuts = '95%'\n",
     "\n",
     "    imviz_sw_cat.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afdddbdd-e01b-43c6-b827-d4683d017466",
+   "metadata": {},
+   "source": [
+    "Now we add the point sources"
    ]
   },
   {
@@ -1669,9 +1725,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c6ce5589-5aa9-414e-ab43-adce292ef11c",
+   "metadata": {},
+   "source": [
+    "We do the same with the LW file. First we visualize the data."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03da0dd5-bd26-425f-8d26-5d7c9d109755",
+   "id": "59a7cce1-4437-4529-8073-9da93e8700d2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1687,6 +1751,14 @@
     "    viewer_lw_cat.cuts = '95%'\n",
     "\n",
     "    imviz_lw_cat.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45a77115-4be8-4b5e-9a45-15a78da35774",
+   "metadata": {},
+   "source": [
+    "No we mark the point sources"
    ]
   },
   {
@@ -1713,7 +1785,7 @@
    "id": "85105f12-83ac-4c19-8f52-3ed2a5e08e27",
    "metadata": {},
    "source": [
-    "## <a id='Notes'>Notes</a>"
+    "## 9. <a id='Notes'>Notes</a>"
    ]
   },
   {
@@ -1721,9 +1793,9 @@
    "id": "f45a68de-194e-4b0d-9ee9-b7ef4d7def42",
    "metadata": {},
    "source": [
-    "- Note that the stratgy presented in this notebook for placing the SW data onto the same pixel grid as the LW data can be applied to data from any two datasets, regardless of filter or channel. By saving the gWCS from the first dataset into an asdf file and providing that file to the Image3 call with the second dataset, the resulting i2d images will be aligned onto the same pixel grid.\n",
+    "- Note that the stratgy presented in this notebook for placing the SW data onto the same pixel grid as the LW data can be applied to data from any two datasets, regardless of filter or channel. By saving the gWCS from the first dataset into an asdf file and providing that file to the `Image3` call with the second dataset, the resulting i2d images will be aligned onto the same pixel grid.\n",
     "\n",
-    "- If you notice poor alignment across tiles within a single i2d image, or between i2d images that you expect to be aligned, try adjusting the parameters in the tweakreg step. With these, you can customize which sources tweakreg identifies and uses for the alignment."
+    "- If you notice poor alignment across tiles within a single i2d image, or between i2d images that you expect to be aligned, try adjusting the parameters in the `tweakreg` step. With these, you can customize which sources `tweakreg` identifies and uses for the alignment."
    ]
   },
   {
@@ -1751,7 +1823,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/NIRCAM/JWpipeNB-nircam-imaging.ipynb
+++ b/notebooks/NIRCAM/JWpipeNB-nircam-imaging.ipynb
@@ -1454,7 +1454,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6615b298-ae83-491a-bfa6-888bcd21ea9e",
+   "id": "06402509-0353-415e-bf1b-5f88af4547f2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1484,6 +1484,90 @@
     "    viewer_lw_i2d.stretch = 'sqrt'\n",
     "    viewer_lw_i2d.set_colormap('Viridis')\n",
     "    viewer_lw_i2d.cuts = '95%'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d94fa17-9f9f-4a6b-a429-509b41b85eb1",
+   "metadata": {},
+   "source": [
+    "Let's try putting the SW and LW images on top of one another to create a color image. This should work regardless of whether you resampled the two images onto the same pixel grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e27c954-fc64-4c44-841e-f420903de226",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage3:\n",
+    "    imviz_color = Imviz()\n",
+    "    viewer_color = imviz_color.default_viewer\n",
+    "\n",
+    "    # Load the datasets into Imviz\n",
+    "    imviz_color.load_data(sw_i2d_file, data_label='sw')\n",
+    "    imviz_color.load_data(lw_i2d_file, data_label='lw')\n",
+    "\n",
+    "    # Link images by WCS (without affine approximation)\n",
+    "    imviz_color.plugins['Links Control'].link_type = 'WCS'\n",
+    "    imviz_color.plugins['Links Control'].wcs_use_affine = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "977092a3-3838-47ba-9040-f5eb819e3d1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define some options to make the picture look nice. Set the colors\n",
+    "# for the two images. \n",
+    "if doimage3:\n",
+    "    plot_options = imviz_color.plugins['Plot Options']\n",
+    "    plot_options.image_color_mode = 'Monochromatic'\n",
+    "    img_settings = {'sw': {'image_color': '#61d3e1',\n",
+    "                           #'stretch_vmin': 0,\n",
+    "                           #'stretch_vmax': 4,\n",
+    "                           #'image_opacity': 0.32,\n",
+    "                           #'image_contrast': 0.69,\n",
+    "                           #'image_bias': 0.39\n",
+    "                          },\n",
+    "                    'lw': {'image_color': '#ff767c',\n",
+    "                           #'stretch_vmin': 0,\n",
+    "                           #'stretch_vmax': 16,\n",
+    "                           #'image_opacity': 0.4,\n",
+    "                           #'image_contrast': 0.94,\n",
+    "                           #'image_bias': 0.74\n",
+    "                          }\n",
+    "                   }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aaca2457-d10d-4d94-89a7-e46e6528acf5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now populate the imviz instance with the settings in the cell above.\n",
+    "if doimage3:\n",
+    "    for layer, settings in img_settings.items():\n",
+    "        plot_options.layer = f'{layer}[DATA]'\n",
+    "        for k, v in settings.items():\n",
+    "            setattr(plot_options, k, v)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed6cd5f7-77ba-49ae-b4b2-20e00e26144d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the dataset\n",
+    "if doimage3:\n",
+    "    imviz_color.show()"
    ]
   },
   {
@@ -1667,7 +1751,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
NIRCam Imaging Notebook - Code Review

Updated information sections format
Updated paragraph for CRDS as we are now moving into Data rRelease mode
Fixed links to sections.
Added number to Notes section to be 9. This for consinstency
Added a link to MAST search page
In Cell 2 changes the user_home_dir to the PID and Obs given in this notebook
Changed the context to use the context that applies to build 1.15.1 
Changed wording in the CRDS cell to read 
“Set CRDS context (if overriding to use a specific version of reference
 files; leave commented out to use the default context. This is, the latest 
 reference files associated with the version of the calibration pipeline)”

 Implementation to associate a context with a version of the jwst Calibration
 pipeline will be released soon, until that happens we will set the context to the 
 correct one for the version of the jwst Calibration pipeline used here."

This assumes that by the time this notebooks is public CRDS would be able to assign a context with the given version of the calibration pipeline; however, things are taking longer

Added a few comments to the cell to clarify what was happening. Nothing major.
Changed the AsdfFile path to Image3 directory, otherwise the code crashes.
14. Added information about the filter correspondence to SW and LW cases in description
15. When creating the association I clarified F200W = SW and F444W = LW
16. Changed mention to image3_fxxxw products in the Visualization section as the data was not named that way throughout the notebook.
17. Added the cells for Imvix to overly the observations that Bryan added 
